### PR TITLE
[b] Fix looping bug when load paginated results

### DIFF
--- a/lib/microsoft_graph/collection_association.rb
+++ b/lib/microsoft_graph/collection_association.rb
@@ -159,7 +159,7 @@ class MicrosoftGraph
 
     def each(start = 0)
       return to_enum(:each, start) unless block_given?
-      @next_link = query_path
+      @next_link ||= query_path
       Array(@internal_values[start..-1]).each do |element|
         yield(element)
       end
@@ -207,6 +207,8 @@ class MicrosoftGraph
         end
       end
       @next_link = result[:attributes]['@odata.next_link']
+      @next_link.sub!(MicrosoftGraph::BASE_URL, "") if @next_link
+
       result[:attributes]['value'].each do |entity_hash|
         klass =
           if member_type = specified_member_type(entity_hash)
@@ -216,7 +218,7 @@ class MicrosoftGraph
           end
         @internal_values.push klass.new(attributes: entity_hash, parent: self, persisted: true)
       end
-      @loaded = result[:attributes]['@odata.next_link'].nil?
+      @loaded = @next_link.nil?
     end
 
     def default_member_class

--- a/microsoft_graph.gemspec
+++ b/microsoft_graph.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov", "~> 0.11.1"
   spec.add_development_dependency "webmock", "~> 1.22.6"
 
-  spec.add_dependency "nokogiri", "~> 1.6.7.1"
+  spec.add_dependency "nokogiri", "~> 1.6.7"
 end

--- a/spec/microsoft_graph/collection_association_spec.rb
+++ b/spec/microsoft_graph/collection_association_spec.rb
@@ -183,7 +183,8 @@ describe MicrosoftGraph::CollectionAssociation do
         ]
       }
       stub_request(:get, "https://graph.microsoft.com/v1.0/users/USER123/calendars")
-        .to_return({ body: first_page_body.to_json }).times(1).then
+        .to_return({ body: first_page_body.to_json }).times(1)
+      stub_request(:get, "https://graph.microsoft.com/v1.0/users/USER123/calendars?$skip=1")
         .to_return({ body: second_page_body.to_json }).times(1)
     end
     Given(:me) { graph.me }


### PR DESCRIPTION
- Nokogiri 1.6.8 has fixed many security issues that are recommended to upgrade for all 1.6.x users.

- There's a bug in loading paginated results that cause the @next_link value to be reset to the query path of first page, thus making the process looped.