### PR TITLE
uninitialized constant MicrosoftGraph::Base

### DIFF
--- a/lib/microsoft_graph.rb
+++ b/lib/microsoft_graph.rb
@@ -6,7 +6,7 @@ Dir[
     'microsoft_graph',
     '*'
   )
-].each { |f| require f }
+].sort.each { |f| require f }
 
 class MicrosoftGraph
   attr_reader :service


### PR DESCRIPTION
Mac OS X + RVM: it requires files sorted by name so base.rb is first
Ubuntu + RVM : it doesn't require files sorted by name so base.rb is not first and it doesn't load all classes and creates uninitialized constant MicrosoftGraph::Base