### PR TITLE
[Feature] Adds support for specifying API version

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ tokens        = context.acquire_token_for_user(resource, client_cred, user_cred)
 # add the access token to the request header
 callback = Proc.new { |r| r.headers["Authorization"] = "Bearer #{tokens.access_token}" }
 
-graph = MicrosoftGraph.new(
-                            base_url: "https://graph.microsoft.com/v1.0",
-                            cached_metadata_file: File.join(MicrosoftGraph::CACHED_METADATA_DIRECTORY, "metadata_v1.0.xml"),
-                            &callback
+graph = MicrosoftGraph.new(base_url: "https://graph.microsoft.com/v1.0",
+                           cached_metadata_file: File.join(MicrosoftGraph::CACHED_METADATA_DIRECTORY, "metadata_v1.0.xml"),
+                           api_version: '1.6', # Optional
+                           &callback
 )
 
 me = graph.me # get the current user

--- a/lib/microsoft_graph.rb
+++ b/lib/microsoft_graph.rb
@@ -14,9 +14,10 @@ class MicrosoftGraph
 
   def initialize(options = {}, &auth_callback)
     @service = OData::Service.new(
+      api_version: options[:api_version],
+      auth_callback: auth_callback,
       base_url: BASE_URL,
-      metadata_file: options[:cached_metadata_file],
-      auth_callback: auth_callback
+      metadata_file: options[:cached_metadata_file]
     )
     @association_collections = {}
     unless MicrosoftGraph::ClassBuilder.loaded?

--- a/lib/odata/service.rb
+++ b/lib/odata/service.rb
@@ -4,6 +4,9 @@ module OData
     attr_reader :metadata
 
     def initialize(options = {}, &block)
+      @api_version   = {
+        'api-version': options[:api_version]
+      } if options[:api_version]
       @auth_callback = options[:auth_callback] || block
       @base_url      = options[:base_url]
       @metadata_file = options[:metadata_file]
@@ -64,7 +67,17 @@ module OData
     end
 
     def request(options = {})
-      req = Request.new(options[:method], options[:uri], options[:data])
+      uri = options[:uri]
+
+      if @api_version then
+        parsed_uri = URI(uri)
+        params = URI.decode_www_form(parsed_uri.query || '')
+                    .concat(@api_version.to_a)
+        parsed_uri.query = URI.encode_www_form params
+        uri = parsed_uri.to_s
+      end
+
+      req = Request.new(options[:method], uri, options[:data])
       @auth_callback.call(req) if @auth_callback
       req.perform
     end


### PR DESCRIPTION
Tenants at https://graph.windows.net/ require the `api-version` query parameter to be present for any API calls. The use of `api-version` is described in [1]

This pull request adds a new (optional) API version option to tag all requests invoked from the Microsoft Graph instance.

[1] https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-graph-api-quickstart#graph-api-versions