### PR TITLE
Fix "undefined method `member_type'" when accessing masterCategories

### DIFF
--- a/lib/odata/service.rb
+++ b/lib/odata/service.rb
@@ -174,7 +174,8 @@ module OData
         singular, segments = segments_from_odata_context_field(context)
         first_entity_type = get_type_by_name("Collection(#{entity_set_by_name(segments.shift).member_type})")
         entity_type = segments.reduce(first_entity_type) do |last_entity_type, segment|
-          last_entity_type.member_type.navigation_property_by_name(segment).type
+          member_type = last_entity_type.respond_to?(:member_type) ? last_entity_type.member_type : last_entity_type
+          member_type.navigation_property_by_name(segment).type
         end
         singular && entity_type.respond_to?(:member_type) ? entity_type.member_type : entity_type
       end


### PR DESCRIPTION
Hi, I'm trying to get the master categories with the gem, but either I get nothing or an exception is raised.

If I try to get the categories using the gem generated classes, I get nothing:

```ruby
graph.me.outlook.master_categories.as_json => []
```

If I call the service directly, I get an exception:

```ruby
graph.service.get('me/outlook/masterCategories')

NoMethodError: undefined method `member_type' for #<OData::EntityType:0x000055cebd0ba018>
from [redacted]/.rvm/gems/ruby-2.5.1@alkimii/bundler/gems/msgraph-sdk-ruby-925a65ee14ad/lib/odata/service.rb:177:in `block in get_type_for_odata_response'
```

Debugging the code I [see](https://github.com/microsoftgraph/msgraph-sdk-ruby/blob/b21d5e1956a078606bbee4f686033d08edbd6a61/lib/odata/service.rb#L177)  that `get_type_for_odata_response` method does not take in account mixed Collection/Entity in the result, and it thinks all intermediate segments are collections. When I change 
```ruby
last_entity_type.member_type.navigation_property_by_name(segment).type
```
 by 
```ruby
member_type = last_entity_type.respond_to?(:member_type) ? last_entity_type.member_type : last_entity_type
member_type.navigation_property_by_name(segment).type
```
It finally gets the categories.