### PR TITLE
Fixed to not depend on adal.

### DIFF
--- a/integration_spec/integration_spec_helper.rb
+++ b/integration_spec/integration_spec_helper.rb
@@ -1,18 +1,23 @@
 require "common_spec_helper"
 require "dotenv"
 Dotenv.load
-# ADAL::Logging.log_level = ADAL::Logger::VERBOSE
 
+BASE_URL      = ENV['MS_GRAPH_BASE_URL']
+TOKEN_PATH    = ENV['MS_GRAPH_TOKEN_PATH']
 TENANT        = ENV['MS_GRAPH_TENANT']
-USERNAME      = ENV['MS_GRAPH_USERNAME']
-PASSWORD      = ENV['MS_GRAPH_PASSWORD']
 CLIENT_ID     = ENV['MS_GRAPH_CLIENT_ID']
 CLIENT_SECRET = ENV['MS_GRAPH_CLIENT_SECRET']
-RESOURCE      = 'https://graph.microsoft.com'
 
-USER_CRED   = ADAL::UserCredential.new(USERNAME, PASSWORD)
-CLIENT_CRED = ADAL::ClientCredential.new(CLIENT_ID, CLIENT_SECRET)
-CONTEXT     = ADAL::AuthenticationContext.new(ADAL::Authority::WORLD_WIDE_AUTHORITY, TENANT)
-TOKENS      = CONTEXT.acquire_token_for_user(RESOURCE, CLIENT_CRED, USER_CRED)
+RESPONSE = HTTParty.post(
+  "#{BASE_URL}/#{TENANT}/#{TOKEN_PATH}",
+  multipart: true,
+  body: {
+    client_id: CLIENT_ID,
+    client_secret: CLIENT_SECRET,
+    scope: 'https://graph.microsoft.com/.default',
+    grant_type: 'client_credentials'
+  }
+)
+TOKEN = JSON.parse(RESPONSE.body)['access_token']
 
-create_classes(TOKENS)
+create_classes(TOKEN)

--- a/integration_spec/integration_spec_helper.rb
+++ b/integration_spec/integration_spec_helper.rb
@@ -8,14 +8,15 @@ TENANT        = ENV['MS_GRAPH_TENANT']
 CLIENT_ID     = ENV['MS_GRAPH_CLIENT_ID']
 CLIENT_SECRET = ENV['MS_GRAPH_CLIENT_SECRET']
 
-RESPONSE = HTTParty.post(
+client = HTTPClient.new
+RESPONSE = client.post(
   "#{BASE_URL}/#{TENANT}/#{TOKEN_PATH}",
   multipart: true,
   body: {
     client_id: CLIENT_ID,
     client_secret: CLIENT_SECRET,
     scope: 'https://graph.microsoft.com/.default',
-    grant_type: 'client_credentials'
+    grant_type: 'client_credentials',
   }
 )
 TOKEN = JSON.parse(RESPONSE.body)['access_token']

--- a/integration_spec/integration_spec_helper.rb
+++ b/integration_spec/integration_spec_helper.rb
@@ -1,6 +1,7 @@
 require "common_spec_helper"
 require "dotenv"
 Dotenv.load
+require 'net/http'
 
 BASE_URL      = ENV['MS_GRAPH_BASE_URL']
 TOKEN_PATH    = ENV['MS_GRAPH_TOKEN_PATH']

--- a/integration_spec/live_spec.rb
+++ b/integration_spec/live_spec.rb
@@ -2,7 +2,7 @@ require_relative "integration_spec_helper"
 
 describe MicrosoftGraph::User do
   Given(:auth_callback) {
-    Proc.new { |r| r.headers["Authorization"] = "Bearer #{TOKENS.access_token}" }
+    Proc.new { |r| r.headers["Authorization"] = "Bearer #{TOKEN}" }
   }
   Given(:test_run_id) { rand(2**128) }
   Given(:graph) { MicrosoftGraph.new(&auth_callback) }

--- a/microsoft_graph.gemspec
+++ b/microsoft_graph.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry", "~> 0.10.3"
   spec.add_development_dependency "simplecov", "~> 0.11.1"
   spec.add_development_dependency "webmock", "~> 1.22.6"
+  spec.add_development_dependency "httparty", "0.17.0"
 
   spec.add_dependency "nokogiri", ">= 1.8.0"
 end

--- a/microsoft_graph.gemspec
+++ b/microsoft_graph.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry", "~> 0.10.3"
   spec.add_development_dependency "simplecov", "~> 0.11.1"
   spec.add_development_dependency "webmock", "~> 1.22.6"
-  spec.add_development_dependency "httparty", "0.17.0"
+  spec.add_development_dependency "httpclient", "~> 2.8.3"
 
   spec.add_dependency "nokogiri", ">= 1.8.0"
 end

--- a/microsoft_graph.gemspec
+++ b/microsoft_graph.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-given", "~> 3.5.0"
-  spec.add_development_dependency "adal", "~> 1.0"
   spec.add_development_dependency "dotenv", "~> 2.0.2"
   spec.add_development_dependency "pry", "~> 0.10.3"
   spec.add_development_dependency "simplecov", "~> 0.11.1"

--- a/spec/common_spec_helper.rb
+++ b/spec/common_spec_helper.rb
@@ -7,15 +7,16 @@ require "rspec"
 require 'rspec/given'
 require "nokogiri"
 require "pry"
+require "httparty"
 
 require "microsoft_graph"
 
-def create_classes(tokens = nil)
+def create_classes(token = nil)
   service = OData::Service.new(
     base_url: "https://graph.microsoft.com/v1.0/",
     namespace: "microsoft.graph",
     metadata_file: File.join(MicrosoftGraph::CACHED_METADATA_DIRECTORY, "metadata_v1.0.xml"),
-    auth_token: tokens && tokens.access_token,
+    auth_token: token,
   )
   MicrosoftGraph::ClassBuilder.load!(service)
   service

--- a/spec/common_spec_helper.rb
+++ b/spec/common_spec_helper.rb
@@ -7,7 +7,7 @@ require "rspec"
 require 'rspec/given'
 require "nokogiri"
 require "pry"
-require "httparty"
+require "httpclient"
 
 require "microsoft_graph"
 

--- a/spec/common_spec_helper.rb
+++ b/spec/common_spec_helper.rb
@@ -5,11 +5,7 @@ end
 
 require "rspec"
 require 'rspec/given'
-
-# NOTE: Please remove this line if https://github.com/AzureAD/azure-activedirectory-library-for-ruby/pull/50 is released.
-require "adal/request_parameters"
-
-require "adal"
+require "nokogiri"
 require "pry"
 
 require "microsoft_graph"


### PR DESCRIPTION
`microsoft_grapsh` depends on `adal`. However, it is `nokogiri` that `microsoft_grapsh` really depends on it. So I deleted `adal`.