### PR TITLE
Allow filter and order

### DIFF
--- a/lib/microsoft_graph/collection_association.rb
+++ b/lib/microsoft_graph/collection_association.rb
@@ -14,7 +14,6 @@ class MicrosoftGraph
       @loaded          = false
       @internal_values = []
 
-      raise MicrosoftGraph::TypeError.new("A collection cannot be both ordered and filtered.") if @order_by && @filter
       @order_by && @order_by.each do |field|
         field_name, direction = field.to_s.split(' ')
         field_names = field_name.split("/")

--- a/spec/microsoft_graph/collection_association_spec.rb
+++ b/spec/microsoft_graph/collection_association_spec.rb
@@ -276,13 +276,6 @@ describe MicrosoftGraph::CollectionAssociation do
         Then { result.query_path == 'users/userID/messages?$orderby=from/emailAddress/address'}
       end
     end
-
-    describe "raises an error if called on a filtered collection" do
-      When(:filtered) { subject.filter(surname: 'Hayden') }
-      When(:result) { filtered.order_by(:given_name) }
-      Then { result == Failure(MicrosoftGraph::TypeError) }
-    end
-
   end
 
   describe "#filter" do
@@ -304,12 +297,6 @@ describe MicrosoftGraph::CollectionAssociation do
     describe "returns a new collection filtered by any number of fields" do
       When(:result) { subject.filter(surname: 'Puma', given_name: 'Pete') }
       Then { result.query_path == "users?$filter=givenName%20eq%20'Pete'%20and%20surname%20eq%20'Puma'" }
-    end
-
-    describe "raises an error if called on an ordered collection" do
-      When(:ordered) { subject.order_by(:surname) }
-      When(:result) { ordered.filter(given_name: 'Alice') }
-      Then { result == Failure(MicrosoftGraph::TypeError) }
     end
 
     describe "raises an error when passed an invalid field" do


### PR DESCRIPTION
The [docs say](https://docs.microsoft.com/en-us/previous-versions/office/office-365-api/api/version-2.0/complex-types-for-mail-contacts-calendar#search-requests):

> You cannot use `$filter` or `$orderby` in a search request. If you do, you will receive an error message like this one.

But this gem doesn't support the `search` param (I think) and they are allowed to be used together as long as the search param is not used.

Related issue: https://github.com/microsoftgraph/msgraph-sdk-ruby/issues/10