### PR TITLE
Propagate setting dirty flags upwards

### DIFF
--- a/lib/microsoft_graph/base.rb
+++ b/lib/microsoft_graph/base.rb
@@ -112,7 +112,7 @@ class MicrosoftGraph
         if attributes.keys.include?(property_key.to_s)
           value = attributes[property_key.to_s]
           @cached_property_values[property_key] =
-              if property.collection?
+            if property.collection?
               Collection.new(property.type, value)
             elsif klass = MicrosoftGraph::ClassBuilder.get_namespaced_class(property.type.name)
               klass.new(attributes: value)

--- a/lib/microsoft_graph/base.rb
+++ b/lib/microsoft_graph/base.rb
@@ -115,7 +115,7 @@ class MicrosoftGraph
             if property.collection?
               Collection.new(property.type, value)
             elsif klass = MicrosoftGraph::ClassBuilder.get_namespaced_class(property.type.name)
-              klass.new(attributes: value)
+              klass.new(attributes: value, parent_property: self, name: property_key)
             else
               if from_server && ! property.type_match?(value) && OData::EnumType === property.type
                 value.to_s


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-sdk-ruby/issues/46

This PR is to fix 2 Issues

Issue 1
-----------------------------------------------------
For the first issue, say I run the following code
```
    event = graph.me.events.find(outlook_id)
    event.start.date_time = DateTime.now.iso8601
    event.save!
```

it will not update the events start time.

By digging around, I noticed that if I call the `date_time=` method, though it sets the dirty flags for
`event.start` but doesn't change `event`'s dirty flags.

As a result, when it tries to serialize the event for updating, it will not serialize the start property.

Issue 2
-----------------------------------------------------
For the second issue

say as a hack, to solve the first issue I run the following code
```
    event = graph.me.events.find(outlook_id)
    event.start.date_time = DateTime.now.iso8601
    event.start = event.start
    event.save!
```
this does set `start` as dirty, but the issue is the `as_json` method propagate the same options to its children.
Since the only key in the options is based only on the `@dirty_properties.keys` of the event object, the options will look like `{ only: [:start] }`

The issue with this is when it calls `event.start.as_json(options)` there are no options for `start`'s dirty properties, causing the final json to look like `{ "start": { } }` which causes an error.

Fix 1
---------------------------------------
To solve the first issue, when defining the properties, as part of the `Base` class, I add a instance_variable called `@parent_property` and `@name` which are passed in `initialize_serialized_properties`

`klass.new(attributes: value, parent_property: self, name: property_key)`

as well as add a function to deal with setting the dirty flags as well as propagate that upwards

```
    def set_dirty!(property_name)
      self.dirty = true
      self.dirty_properties[property_name] = true
      if parent_property.present?
        parent_property.set_dirty!(OData.convert_to_snake_case(self.name).to_sym)
      end
    end
```

Fix 2
------------------------------------------
To fix issue 2, I just make the `as_json` check if the value is a property object, then sets only to its `dirty_properties`

```
        result[k.to_s] = if MicrosoftGraph::Base === v
                           new_options = options.clone
                           new_options[:only] = v.dirty_properties.keys
                           v.as_json(new_options)
                         elsif v.respond_to?(:as_json)
                           v.as_json(options)
                         else
                           v
                         end
```