### PR TITLE
Update example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ require "microsoft_graph_core"
 
 context = MicrosoftKiotaAuthenticationOAuth::ClientCredentialContext.new("<the tenant id from your app registration>", "<the client id from your app registration>", "<the client secret from your app registration>")
 
-authentication_provider = MicrosoftGraphCore::Authentication::OAuthAuthenticationProvider.new(context, nil, ["Files.Read"])
+authentication_provider = MicrosoftGraphCore::Authentication::OAuthAuthenticationProvider.new(context, nil, ["https://graph.microsoft.com/.default"])
 ```
 
 ### 2.3 Get a Graph Service Client and Adapter object
@@ -55,8 +55,9 @@ After you have a **MicrosoftGraphServiceClient** that is authenticated, you can 
 To retrieve the user's drive:
 
 ```ruby
-result = client.me.drive.get.resume
-puts "Found Drive : " + result.id
+user_item_req_builder = client.users_by_id '9327b2bb-74b9-4d22-9839-eff4a982f541'
+result = user_item_req_builder.get.resume
+puts "Found User : " + result.id
 ```
 
 ## 4. Getting results that span across multiple pages

--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ After you have a **MicrosoftGraphServiceClient** that is authenticated, you can 
 To retrieve the user's drive:
 
 ```ruby
-user_item_req_builder = client.users_by_id '9327b2bb-74b9-4d22-9839-eff4a982f541'
-result = user_item_req_builder.get.resume
+result = client.users_by_id('<user-id>').get.resume
 puts "Found User : " + result.id
 ```
 


### PR DESCRIPTION
Updated README example, since the given example does not work.

Scope update to use 'https://graph.microsoft.com/.default' rather than 'User.Read' as we get the following error
```
OAuth2::Error (invalid_scope: AADSTS1002012: The provided value for scope User.Read is not valid. Client credential flows must have ) scope value with /.default suffixed to the resource identifier (application ID URI).
Trace ID: 44e61acd-c6b7-483f-b3bc-9a6164cc3e00
Correlation ID: 11c0af7b-eb8d-4555-9fdc-2002a11730b4
Timestamp: 2023-07-11 17:05:18Z
{"error":"invalid_scope","error_description":"AADSTS1002012: The provided value for scope User.Read is not valid. Client credential flows must have a scope value with /.default suffixed to the resource identifier (application ID URI).\r\nTrace ID: 44e61acd-c6b7-483f-b3bc-9a6164cc3e00\r\nCorrelation ID: 11c0af7b-eb8d-4555-9fdc-2002a11730b4\r\nTimestamp: 2023-07-11 17:05:18Z","error_codes":[1002012],"timestamp":"2023-07-11 17:05:18Z","trace_id":"44e61acd-c6b7-483f-b3bc-9a6164cc3e00","correlation_id":"11c0af7b-eb8d-4555-9fdc-2002a11730b4"}
```

Update example to query users by id, since the client-credentials cannot get user specific data.
```
MicrosoftGraph::Models::ODataErrors::ODataError (MicrosoftGraph::Models::ODataErrors::ODataError)
```
